### PR TITLE
MacOS split fails due to changed exec-output format

### DIFF
--- a/src/main/java/com/github/sarxos/securetoken/impl/Hardware4Mac.java
+++ b/src/main/java/com/github/sarxos/securetoken/impl/Hardware4Mac.java
@@ -39,11 +39,11 @@ public class Hardware4Mac {
 
 		BufferedReader br = new BufferedReader(new InputStreamReader(is));
 		String line = null;
-		String marker = "Serial Number:";
+		String marker = "Serial Number";
 		try {
 			while ((line = br.readLine()) != null) {
-				if (line.indexOf(marker) != -1) {
-					sn = line.split(marker)[1].trim();
+				if (line.contains(marker)) {
+					sn = line.split(":")[1].trim();
 					break;
 				}
 			}


### PR DESCRIPTION
It seems like the format of the exec-output has changed in MacOS. It doesn't start with "Serial Number:" anymore but with "Serial Number (system):". As I don't known whether this is the case on all Macs I changed the code so that it checks whether a line contains the string "Serial Number" (but without the colon) and if that is the case it splits the line at the colon instead of the string "Serial Number:". Works fine on my mid 2012 MBP.
